### PR TITLE
Add API proxy to Vite config

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:4000'
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- configure Vite dev server to forward `/api` to the backend server

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*