### PR TITLE
Fix start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.cjs"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- use `server.cjs` in root start script

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'dotenv')*